### PR TITLE
Add Routes for Reviews API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ venv/
 reviews_API/logger/__pycache__/
 reviews_API/models/__pycache__/
 reviews_API/services/__pycache__/
-reviews_API/services/__pycache__/
+reviews_API/routes/__pycache__/
 reviews_API/__pycache__/
 atemporal_api.log
+atemporal_reviews_api.log

--- a/reviews_API/routes/reviews_routes.py
+++ b/reviews_API/routes/reviews_routes.py
@@ -14,6 +14,9 @@ class ReviewRoute(Blueprint):
     def register_routes(self):
         self.route("/api/v1/reviews", methods=["GET"])(self.get_reviews)
         self.route("/api/v1/reviews", methods=["POST"])(self.add_review)
+        self.route("/api/v1/reviews/<int:review_id>", methods=["PUT"])(
+            self.update_review
+        )
 
     def get_reviews(self):
         reviews = self.review_service.get_all_reviews()
@@ -62,3 +65,33 @@ class ReviewRoute(Blueprint):
         except Exception as e:
             self.logger.error(f"Error adding review: {e}")
             return jsonify({"error": f"Error adding review: {e}"}), 500
+
+    def update_review(self, review_id):
+        try:
+            user, product, review, rating = self.fetch_request_data()
+
+            try:
+                self.review_schema.validates_user(user)
+                self.review_schema.validates_product(product)
+                self.review_schema.validates_review(review)
+                self.review_schema.validates_rating(rating)
+            except ValidationError as e:
+                return jsonify({"error": f"Invalid data: {e}"}), 400
+
+            update_review = {
+                "_id": review_id,
+                "user": user,
+                "product": product,
+                "review": review,
+                "rating": rating,
+            }
+
+            updated_review = self.review_service.update_review(review_id, update_review)
+            if updated_review:
+                return jsonify(updated_review), 200
+            else:
+                return jsonify({"error": "Review not found"}), 404
+
+        except Exception as e:
+            self.logger.error(f"Error updating review: {e}")
+            return jsonify({"error": f"Error updating review: {e}"}), 500

--- a/reviews_API/routes/reviews_routes.py
+++ b/reviews_API/routes/reviews_routes.py
@@ -36,6 +36,14 @@ class ReviewRoute(Blueprint):
             review = request_data.get("review")
             rating = request_data.get("rating")
 
+            try:
+                self.review_schema.validates_user(user)
+                self.review_schema.validates_product(product)
+                self.review_schema.validates_review(review)
+                self.review_schema.validates_rating(rating)
+            except ValidationError as e:
+                return jsonify({"error": f"Invalid data: {e}"}), 400
+
             return user, product, review, rating
 
         except Exception as e:
@@ -45,14 +53,6 @@ class ReviewRoute(Blueprint):
     def add_review(self):
         try:
             user, product, review, rating = self.fetch_request_data()
-
-            try:
-                self.review_schema.validates_user(user)
-                self.review_schema.validates_product(product)
-                self.review_schema.validates_review(review)
-                self.review_schema.validates_rating(rating)
-            except ValidationError as e:
-                return jsonify({"error": f"Invalid data: {e}"}), 400
 
             new_review = {
                 "user": user,
@@ -72,14 +72,6 @@ class ReviewRoute(Blueprint):
     def update_review(self, review_id):
         try:
             user, product, review, rating = self.fetch_request_data()
-
-            try:
-                self.review_schema.validates_user(user)
-                self.review_schema.validates_product(product)
-                self.review_schema.validates_review(review)
-                self.review_schema.validates_rating(rating)
-            except ValidationError as e:
-                return jsonify({"error": f"Invalid data: {e}"}), 400
 
             update_review = {
                 "_id": review_id,

--- a/reviews_API/routes/reviews_routes.py
+++ b/reviews_API/routes/reviews_routes.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, jsonify, request
+from marshmallow import ValidationError
+from reviews_API.logger.logger_base import Logger
+
+
+class ReviewRoute(Blueprint):
+    def __init__(self, review_service, review_schema):
+        super().__init__("review", __name__)
+        self.logger = Logger()
+        self.review_service = review_service
+        self.review_schema = review_schema
+        self.register_routes()
+
+    def register_routes(self):
+        self.route("/api/v1/reviews", methods=["GET"])(self.get_reviews)
+        # self.route("/api/v1/reviews", methods=["POST"])(self.add_review)
+
+    def get_reviews(self):
+        reviews = self.review_service.get_all_reviews()
+        return jsonify(reviews), 200

--- a/reviews_API/routes/reviews_routes.py
+++ b/reviews_API/routes/reviews_routes.py
@@ -17,6 +17,9 @@ class ReviewRoute(Blueprint):
         self.route("/api/v1/reviews/<int:review_id>", methods=["PUT"])(
             self.update_review
         )
+        self.route("/api/v1/reviews/<int:review_id>", methods=["DELETE"])(
+            self.delete_review
+        )
 
     def get_reviews(self):
         reviews = self.review_service.get_all_reviews()
@@ -95,3 +98,15 @@ class ReviewRoute(Blueprint):
         except Exception as e:
             self.logger.error(f"Error updating review: {e}")
             return jsonify({"error": f"Error updating review: {e}"}), 500
+
+    def delete_review(self, review_id):
+        try:
+            deleted_review = self.review_service.delete_review(review_id)
+            if deleted_review:
+                return jsonify(deleted_review), 200
+            else:
+                return jsonify({"error": "Review not found"}), 404
+
+        except Exception as e:
+            self.logger.error(f"Error deleting review: {e}")
+            return jsonify({"error": f"Error deleting review: {e}"}), 500


### PR DESCRIPTION
**Description:**
This PR implements the reviews routes, enabling CRUD operations via RESTful endpoints. It also introduces a helper function to streamline data fetching and validation in the `POST` and `PUT` routes. Updates were also made to the `.gitignore` file.

**Changes:**
   - **GET** (`/api/v1/reviews`)
     - Added a route to retrieve a list of all reviews.
   - **POST** (`/api/v1/reviews`)
     - Added a route to create a new review with data validation.
   - **PUT** (`/api/v1/reviews/<int:review_id>`)
     - Added a route to update an existing review by ID.
   - **DELETE** (`/api/v1/reviews/<int:review_id>`)
     - Added a route to delete a review by ID.
   - Added `fetch_request_data` to reduce code repetition for fetching and validating request data in the `POST` and `PUT` routes.
   - Updated `.gitignore` to exclude `__pycache__` files generated within the `routes` directory.

**Impact:**
- Provides full CRUD functionality for managing reviews through RESTful API endpoints.
- Improves code maintainability by introducing a reusable helper function.

**Testing:**
- Test each route (`GET`, `POST`, `PUT`, `DELETE`) to ensure expected behavior.
- Confirm that invalid data is correctly rejected with appropriate error messages.
- Ensure no unnecessary files from `__pycache__` are tracked in the repository.